### PR TITLE
added subject parameters to certificate enrollment.

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -78,10 +78,16 @@ func (b *backend) initialize(ctx context.Context, req *logical.InitializationReq
 }
 
 // Generate keypair and CSR
-func (b *backend) generateCSR(cn string, ip_sans []string, dns_sans []string) (string, []byte) {
+func (b *backend) generateCSR(cn string, ip_sans []string, dns_sans []string, o []string, ou []string, l []string, p []string, c []string, zip []string) (string, []byte) {
 	keyBytes, _ := rsa.GenerateKey(rand.Reader, 2048)
 	subj := pkix.Name{
-		CommonName: cn,
+		Country:            c,
+		Organization:       o,
+		OrganizationalUnit: ou,
+		Locality:           l,
+		Province:           p,
+		CommonName:         cn,
+		PostalCode:         zip,
 	}
 	rawSubj := subj.ToRDNSequence()
 	asn1Subj, _ := asn1.Marshal(rawSubj)

--- a/fields.go
+++ b/fields.go
@@ -67,6 +67,48 @@ be larger than the role max TTL.`,
 		},
 	}
 
+	// fields["email"] = &framework.FieldSchema{
+	// 	Type: framework.TypeCommaStringSlice,
+	// 	Description: `Email address to be associated with the certificate`,
+	// 	Required:    false,
+	// }
+
+	fields["c"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Country for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
+	fields["ou"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Organizational Unit for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
+	fields["o"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Organization for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
+	fields["l"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Locality for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
+	fields["p"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Province for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
+	fields["zip"] = &framework.FieldSchema{
+		Type:        framework.TypeCommaStringSlice,
+		Description: `Postal code for the certificate.  If omitted, the value associated with the role is used.`,
+		Required:    false,
+	}
+
 	return fields
 }
 

--- a/path_issue_sign.go
+++ b/path_issue_sign.go
@@ -184,9 +184,38 @@ func (b *backend) pathIssueSignCert(ctx context.Context, req *logical.Request, d
 			return nil, fmt.Errorf("Subject Alternative Name " + dns_sans[u] + " not allowed for provided role")
 		}
 	}
+	ou, ok := data.GetOk("ou")
+	if !ok {
+		ou = role.OU
+	}
+
+	o, ok := data.GetOk("o")
+	if !ok {
+		o = role.Organization
+	}
+
+	c, ok := data.GetOk("c")
+	if !ok {
+		c = role.Country
+	}
+
+	l, ok := data.GetOk("l")
+	if !ok {
+		l = role.Locality
+	}
+
+	p, ok := data.GetOk("p")
+	if !ok {
+		p = role.Province
+	}
+
+	z, ok := data.GetOk("z")
+	if !ok {
+		z = role.PostalCode
+	}
 
 	//generate and submit CSR
-	csr, key := b.generateCSR(cn.(string), ip_sans, dns_sans)
+	csr, key := b.generateCSR(cn.(string), ip_sans, dns_sans, o.([]string), ou.([]string), l.([]string), p.([]string), c.([]string), z.([]string))
 	certs, serial, errr := b.submitCSR(ctx, req, csr, caName, templateName)
 
 	if errr != nil {
@@ -217,6 +246,8 @@ const pathIssueHelpDesc = `
 This path allows requesting a certificate to be issued according to the
 policy of the given role. The certificate will only be issued if the
 requested details are allowed by the role policy.
+
+The values for C, O, OU, L, S, P (province) and zip (postal code) will be retreived from the role if not supplied as parameters.
 
 This path returns a certificate and a private key. If you want a workflow
 that does not expose a private key, generate a CSR locally and use the


### PR DESCRIPTION
Added parameters for the certificate subject fields when generating a new certificate for enrollment.  If missing, it will pull the value from the role used to enroll the certificate.